### PR TITLE
Low dep

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,4 @@
 ^.test.cpp$
 ^\.github$
 ^codemeta\.json$
+^cran-comments\.md$

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ dist: trusty
 cache: packages
 
 r_packages:
+- devtools
 - covr
 
 before_install:

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ Fast sf-to-raster conversion
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/fasterize)](http://www.r-pkg.org/pkg/fasterize)
 
 **fasterize** is high-performance replacement for the `rasterize()` function
-in the [**raster**]() package.
+in the [**raster**](https://cran.r-project.org/package=raster) package.
 
 Functionality is currently limited to rasterizing polygons in [**sf**](https://cran.r-project.org/package=sf)-type
 data frames.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fast sf-to-raster conversion
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active) [![MIT Licensed - Copyright 2016 EcoHealth Alliance](https://img.shields.io/badge/license-MIT-blue.svg)](https://badges.mit-license.org/) [![Linux Build Status](https://travis-ci.org/ecohealthalliance/fasterize.svg?branch=master)](https://travis-ci.org/ecohealthalliance/fasterize) [![Windows Build status](https://ci.appveyor.com/api/projects/status/3n59bs19ovex5d1t?svg=true)](https://ci.appveyor.com/project/NoamRoss/fasterize-7kxl2) [![Coverage Status](https://codecov.io/gh/ecohealthalliance/fasterize/branch/master/graph/badge.svg)](https://codecov.io/gh/ecohealthalliance/fasterize) [![](http://www.r-pkg.org/badges/version/fasterize)](http://www.r-pkg.org/pkg/fasterize) [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/fasterize)](http://www.r-pkg.org/pkg/fasterize)
 
-**fasterize** is high-performance replacement for the `rasterize()` function in the [**raster**]() package.
+**fasterize** is high-performance replacement for the `rasterize()` function in the [**raster**](https://cran.r-project.org/package=raster) package.
 
 Functionality is currently limited to rasterizing polygons in [**sf**](https://cran.r-project.org/package=sf)-type data frames.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,27 @@
+## Resubmission
+This is a resubmission. In this version I have:
+
+-  Found and fixed an the empty link in the vignette.
+
+in response to the comment:
+
+Found the following (possibly) invalid URLs:
+   URL:
+     From: inst/doc/using-fasterize.html
+     Message: Empty URL
+
+Please fix and resubmit.
+
+I have re-tested in the following environments
+* local OS X install, R 3.4.4
+* Linux and Wondows, devel and release, via r-hub
+
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+N  checking CRAN incoming feasibility
+   Maintainer: 'Noam Ross <ross@ecohealthalliance.org>'
+   
+   New submission
+   

--- a/vignettes/using-fasterize.Rmd
+++ b/vignettes/using-fasterize.Rmd
@@ -11,7 +11,7 @@ vignette: >
 
 <!-- As fasterize is a small package, this vignette just copies over the major contents of the README, without badges -->
 
-**fasterize** is high-performance replacement for the `rasterize()` function in the [**raster**]() package.
+**fasterize** is high-performance replacement for the `rasterize()` function in the [**raster**](https://cran.r-project.org/package=raster) package.
 
 Functionality is currently limited to rasterizing polygons in [**sf**](https://cran.r-project.org/package=sf)-type data frames.
 


### PR DESCRIPTION
This PR takes out the import from sf which was for st_bbox and st_crs, both easily replaced by direct attribute access. 

This means we aren't dependent upon GDAL, which is completely unused by fasterize. raster itself has rgdal and sf as Suggests, by the loadNamespace check - so one can choose to use the package without that library. 

I updated

* raster-methods.R
* NAMESPACE
* DESCRIPTION

I haven't changed

* README - which has a note on requiring sf
* .travis.yml - which installs system deps

