### PR TITLE
r_packages + devtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache: packages
 
 r_packages:
 - covr
+- devtools
 
 before_install:
   - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable --yes


### PR DESCRIPTION
Travis .yml add devtools to `r_packages`, seems to fix the Travis/devtools problem. 

(I'm not across the details, just found this https://stackoverflow.com/questions/47775434/travis-error-package-devtools-was-installed-by-an-r-version-with-different-i)