### PR TITLE
remove copy of sf projection to the raster

### DIFF
--- a/src/fasterize.cpp
+++ b/src/fasterize.cpp
@@ -145,14 +145,18 @@ Rcpp::S4 fasterize(Rcpp::DataFrame &sf,
     rasterdata.slot("fromdisk") = false;
     rasterdata.slot("haveminmax") = true;
 
-    Rcpp::CharacterVector sfproj4 =
-      Rcpp::as<Rcpp::StringVector>(
-        Rcpp::as<Rcpp::List>(polygons.attr("crs"))["proj4string"]
-      );
-    if(sfproj4[0] != NA_STRING) {
-      Rcpp::S4 rcrs(raster1.slot("crs"));
-      rcrs.slot("projargs") = sfproj4;
-    }
+    // new sf only stores ()$input and ()$wkt so we have no basis to grab
+    // a PROJ.4 string from that, just assume they are the same
+    // - this wrongly would *assign* the sf projection to the raster if it
+    // was not NA before MDSumner 2020-03-02
+    // Rcpp::CharacterVector sfproj4 =
+    //   Rcpp::as<Rcpp::StringVector>(
+    //     Rcpp::as<Rcpp::List>(polygons.attr("crs"))["proj4string"]
+    //   );
+    // if(sfproj4[0] != NA_STRING) {
+    //   Rcpp::S4 rcrs(raster1.slot("crs"));
+    //   rcrs.slot("projargs") = sfproj4;
+    // }
 
     return raster1;
 
@@ -190,14 +194,14 @@ Rcpp::S4 fasterize(Rcpp::DataFrame &sf,
     rasterdata.slot("haveminmax") = true;
     rasterdata.slot("names") = "layer";
 
-    Rcpp::CharacterVector sfproj4 =
-      Rcpp::as<Rcpp::StringVector>(
-        Rcpp::as<Rcpp::List>(polygons.attr("crs"))["proj4string"]
-      );
-    if(sfproj4[0] != NA_STRING) {
-      Rcpp::S4 rcrs(raster1.slot("crs"));
-      rcrs.slot("projargs") = sfproj4;
-    }
+    // Rcpp::CharacterVector sfproj4 =
+    //   Rcpp::as<Rcpp::StringVector>(
+    //     Rcpp::as<Rcpp::List>(polygons.attr("crs"))["proj4string"]
+    //   );
+    // if(sfproj4[0] != NA_STRING) {
+    //   Rcpp::S4 rcrs(raster1.slot("crs"));
+    //   rcrs.slot("projargs") = sfproj4;
+    // }
 
     return raster1;
   }


### PR DESCRIPTION
* Removed assignment of crs from sf to the raster. 


This is sufficient I think, checking all the possible variants and trying to compare proj strings is very complicated - the doc currently says

```
//' @return A raster of the same size, extent, resolution and projection as the
//' provided raster template.
```

and this was not occurring, if non-NA the vector projection was *copied over* to the raster, with no checks. Unfortunately, this means the answer was always "correct", even if it's not what they intended. 

As described in the return value it's now accurate.   If folks are intending that sf data dictates the output projection then they won't achieve that, but there's really no convenient way to check this so I think the onus must be on users to input data in the same coordinate system. 

(Anything else gets pretty complicated and hardly belongs in this package IMO - if raster moves to WKT, or using PROJ more under the hood then I'd revisit the rationale here - currently raster is broken for these new sf crs objects - for the `raster(sf)` workflow). 